### PR TITLE
Fix render issue, update design a bit

### DIFF
--- a/src/components/CardsList.js
+++ b/src/components/CardsList.js
@@ -2,21 +2,35 @@ import canBeCast from './castingChecker';
 
 export default function CardsList({ cards, mana, totalMana, setControls }) {
   const filteredCards = [];
+  
   cards.forEach((card) => {
     if (canBeCast(card, mana, totalMana, setControls)) {
       filteredCards.push(card);
     }
   });
-
+  
+  console.log(filteredCards);
+  
+  // TODO – improve this function so that it fetches the correct face
+  const getCardImage = (card) => {
+    if (card.image_uris) return card.image_uris.normal;
+    if (card.card_faces) {
+      if (card.card_faces[0].image_uris) return card.card_faces[0].image_uris.normal;
+    } else {
+      return null;
+    }
+  }
+  
   return (
     <ul className="flex flex-wrap justify-center">
       {filteredCards.map((card) => {
-        const { mana_cost, image_uris, id, name } = card;
+        const { mana_cost, image_uris, card_faces, id, name } = card;
+        
         return (
           <li key={id}>
             <img
               className="m-1 rounded-lg w-48 h-64"
-              src={image_uris.normal}
+              src={getCardImage(card)}
               alt={`${name}, ${mana_cost}`}
             />
           </li>

--- a/src/components/CardsList.js
+++ b/src/components/CardsList.js
@@ -9,7 +9,6 @@ export default function CardsList({ cards, mana, totalMana, setControls }) {
     }
   });
   
-  console.log(filteredCards);
   
   // TODO – improve this function so that it fetches the correct face
   const getCardImage = (card) => {

--- a/src/components/ManaFilter.js
+++ b/src/components/ManaFilter.js
@@ -27,7 +27,7 @@ export default function ColorFilter(props) {
 
   return (
     <>
-      <div className="flex flex-row my-4 mx-0">
+      <div className="flex flex-row my-4 mx-1">
         {Object.keys(mana).map((color, index) => {
           return (
             <div key={index} className="flex flex-col items-center">

--- a/src/components/ManaFilter.js
+++ b/src/components/ManaFilter.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { W, U, B, R, G, C } from '../assets/manaSymbols';
 
 const buttonClasses =
-  'flex justify-center items-center text-xl my-2 mx-0 h-10 md:h-8 w-10 md:w-8 border border-gray-400 rounded-full bg-gray-200 active:bg-gray-400';
+  'flex justify-center items-center text-xl my-2 mx-1 h-10 md:h-8 w-10 md:w-8 border border-gray-400 rounded-full bg-gray-200 active:bg-gray-400';
 
 export default function ColorFilter(props) {
   const { mana, handleManaChange, resetMana } = props;
@@ -27,38 +27,36 @@ export default function ColorFilter(props) {
 
   return (
     <>
-      <div className="flex flex-row justify-between my-4 mx-0 max-w-4/5 w-96">
+      <div className="flex flex-row my-4 mx-0">
         {Object.keys(mana).map((color, index) => {
           return (
-            <div key={index} className="flex flex-col items-center w-16">
-              <button
-                className={buttonClasses}
-                type="button"
-                onClick={() => handleManaChange(color, 1)}
-              >
-                +
-              </button>
-              <div className="flex flex-row items-center text-4xl h-10 justify-around w-4/5">
-                {mana[color]}
-                <div className="w-6">{manaSymbol(color)}</div>
+            <div key={index} className="flex flex-col items-center">
+              <div className="flex flex-col justify-around">
+                <button onClick={() => handleManaChange(color, 1)} className="flex flex-col items-center text-2xl px-4">
+                  <span className={mana[color] > 0 ? 'text-black' : 'text-gray-200'}>{mana[color]}</span>
+                  <div className="w-10 block">{manaSymbol(color)}</div>
+                </button>
               </div>
-              <button
-                className={buttonClasses}
-                type="button"
-                onClick={() => handleManaChange(color, -1)}
-              >
-                -
-              </button>
+              <div className="flex flex-row mt-4">
+                <button
+                  className={`${mana[color] > 0 ? 'text-gray-800' : 'text-gray-300'} text-xs px-1.5 py-0.5 rounded bg-gray-100`}
+                  type="button"
+                  onClick={() => handleManaChange(color, -1)}
+                  disabled={mana[color] > 0 ? '' : 'disabled'}
+                >
+                  -1
+                </button>
+              </div>
             </div>
           );
         })}
       </div>
       <button
-        className="text-base mb-4 border border-gray-400 rounded-lg p-1 bg-gray-200 active:bg-gray-400"
+        className="text-sm mb-4 border border-gray-400 rounded-lg px-2 py-1 bg-gray-200 active:bg-gray-400"
         type="reset"
         onClick={() => resetMana()}
       >
-        Reset Mana
+        Clear all
       </button>
     </>
   );


### PR DESCRIPTION
## Changes

**Design**

- From a UI design perspective, the user should be able to very quickly add mana. The previous UI with the + and - buttons on top and below the mana options create a number of pretty distinct click targets, which makes them harder to quickly tap. With these changes, the entire mana symbol and count become the "add" button, which makes it much faster to quickly add mana. The remove action is kept as a button, but less prominent.
- To better afford current state and possible interactions, I've introduced distinct styles for different states like when there's no mana (can't remove mana when there's none, and can't clear all mana when there's none).

**Function**

- The crash with two white mana was due to a missing key `card.image_uris` on double-faced cards, which instead have `card.card_faces`. I've added a super simple function to present the correct image, but it doesn't grab the matched face, just the first one.